### PR TITLE
Upgrade WildFly gRPC to 0.1.2.Final

### DIFF
--- a/29.0.0.Final/provisioning-bare-metal.xml
+++ b/29.0.0.Final/provisioning-bare-metal.xml
@@ -4,7 +4,7 @@
     <feature-pack location="org.wildfly:wildfly-galleon-pack:29.0.0.Final"/>
     <feature-pack location="org.wildfly:wildfly-datasources-galleon-pack:5.0.0.Final"/>
     <feature-pack location="org.keycloak:keycloak-saml-adapter-galleon-pack:999.0.0-SNAPSHOT"/>
-    <feature-pack location="org.wildfly.extras.grpc:wildfly-grpc-feature-pack:0.1.2-SNAPSHOT"/>
+    <feature-pack location="org.wildfly.extras.grpc:wildfly-grpc-feature-pack:0.1.2.Final"/>
     <feature-pack location="org.wildfly:wildfly-myfaces-feature-pack:1.0.0-SNAPSHOT"/>
     <feature-pack location="org.wildfly.extras.graphql:wildfly-microprofile-graphql-feature-pack:2.2.0.Final-SNAPSHOT"/>
 </installation>

--- a/29.0.0.Final/provisioning-cloud.xml
+++ b/29.0.0.Final/provisioning-cloud.xml
@@ -4,7 +4,7 @@
     <feature-pack location="org.wildfly:wildfly-galleon-pack:29.0.0.Final"/>
     <feature-pack location="org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Final"/>
     <feature-pack location="org.wildfly:wildfly-datasources-galleon-pack:5.0.0.Final"/>
-    <feature-pack location="org.wildfly.extras.grpc:wildfly-grpc-feature-pack:0.1.2-SNAPSHOT"/>
+    <feature-pack location="org.wildfly.extras.grpc:wildfly-grpc-feature-pack:0.1.2.Final"/>
     <feature-pack location="org.keycloak:keycloak-saml-adapter-galleon-pack:999.0.0-SNAPSHOT"/>
     <feature-pack location="org.wildfly:wildfly-myfaces-feature-pack:1.0.0-SNAPSHOT"/>
     <feature-pack location="org.wildfly.extras.graphql:wildfly-microprofile-graphql-feature-pack:2.2.0.Final-SNAPSHOT"/>

--- a/29.0.0.Final/tech-preview/provisioning-bare-metal.xml
+++ b/29.0.0.Final/tech-preview/provisioning-bare-metal.xml
@@ -3,5 +3,5 @@
 <installation xmlns="urn:jboss:galleon:provisioning:3.0">
     <feature-pack location="org.wildfly:wildfly-preview-feature-pack:29.0.0.Final"/>
     <feature-pack location="org.wildfly:wildfly-datasources-preview-galleon-pack:5.0.0.Final"/>
-    <feature-pack location="org.wildfly.extras.grpc:wildfly-grpc-preview-feature-pack:0.1.2-SNAPSHOT"/>
+    <feature-pack location="org.wildfly.extras.grpc:wildfly-grpc-preview-feature-pack:0.1.2.Final"/>
 </installation>

--- a/29.0.0.Final/tech-preview/provisioning-cloud.xml
+++ b/29.0.0.Final/tech-preview/provisioning-cloud.xml
@@ -4,5 +4,5 @@
     <feature-pack location="org.wildfly:wildfly-preview-feature-pack:29.0.0.Final"/>
     <feature-pack location="org.wildfly.cloud:wildfly-preview-cloud-galleon-pack:4.0.0.Final"/>
     <feature-pack location="org.wildfly:wildfly-datasources-preview-galleon-pack:5.0.0.Final"/>
-    <feature-pack location="org.wildfly.extras.grpc:wildfly-grpc-preview-feature-pack:0.1.2-SNAPSHOT"/>
+    <feature-pack location="org.wildfly.extras.grpc:wildfly-grpc-preview-feature-pack:0.1.2.Final"/>
 </installation>


### PR DESCRIPTION
Upgrade WildFly gRPC to the latest version for bare-metal and cloud. 